### PR TITLE
 upgrade deps; fix inline layout

### DIFF
--- a/calcit.edn
+++ b/calcit.edn
@@ -302,7 +302,6 @@
                   :type :expr, :by "root", :at 1530679046396, :id "ByE0bkCFzX"
                   :data {
                    "D" {:type :leaf, :by "root", :at 1530679052012, :text "merge", :id "SJXGyAFG7"}
-                   "T" {:type :leaf, :by "root", :at 1530679048415, :text "ui/row", :id "rJQRZ1CFfX"}
                    "b" {:type :leaf, :by "root", :at 1530687396248, :text "ui/flex", :id "Bkijke5fQ"}
                    "j" {
                     :type :expr, :by "root", :at 1530679052558, :id "HySfkRKf7"
@@ -322,13 +321,6 @@
                        "j" {:type :leaf, :by "root", :at 1530687458725, :text "\"32px 16px 80px 16px", :id "S1xfw9kqGm"}
                       }
                      }
-                     "v" {
-                      :type :expr, :by "root", :at 1530687260726, :id "H1SQye9MX"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1530687265508, :text ":justify-content", :id "H1SQye9MXleaf"}
-                       "j" {:type :leaf, :by "root", :at 1530687267147, :text ":center", :id "ry5Qkg5fQ"}
-                      }
-                     }
                      "x" {
                       :type :expr, :by "root", :at 1530687386478, :id "SkeMoJg5G7"
                       :data {
@@ -337,10 +329,10 @@
                       }
                      }
                      "y" {
-                      :type :expr, :by "root", :at 1530687644628, :id "H1BillczQ"
+                      :type :expr, :by "root", :at 1530784539308, :id "rJ-Q7iPsGQ"
                       :data {
-                       "T" {:type :leaf, :by "root", :at 1530687646505, :text ":align-items", :id "H1BillczQleaf"}
-                       "j" {:type :leaf, :by "root", :at 1530687650650, :text ":flex-start", :id "HJvjgxqz7"}
+                       "T" {:type :leaf, :by "root", :at 1530784543696, :text ":text-align", :id "rJ-Q7iPsGQleaf"}
+                       "j" {:type :leaf, :by "root", :at 1530784546173, :text ":center", :id "SJluQjwifQ"}
                       }
                      }
                     }
@@ -2198,17 +2190,25 @@
                   :data {
                    "T" {:type :leaf, :author "root", :time 1499755354983, :text "[]", :id "ryROgodKcpSZ"}
                    "b" {
-                    :type :expr, :by "root", :at 1530688621833, :id "HyLONlqf7"
+                    :type :expr, :by "root", :at 1530784192746, :id "r1F6KDsf7"
                     :data {
-                     "D" {:type :leaf, :by "root", :at 1530688623527, :text "str", :id "ByPdVlqf7"}
-                     "L" {
-                      :type :expr, :by "root", :at 1530688637521, :id "SJUFEgqfm"
+                     "D" {:type :leaf, :by "root", :at 1530784194406, :text "if", :id "SJ9pYwjfm"}
+                     "L" {:type :leaf, :by "root", :at 1530784202235, :text "local-bundle?", :id "ByjTtvsMX"}
+                     "P" {:type :leaf, :by "root", :at 1530784204380, :text "\"./fontawesome/css/font-awesome.css", :id "rJeVCKvofX"}
+                     "T" {
+                      :type :expr, :by "root", :at 1530688621833, :id "HyLONlqf7"
                       :data {
-                       "T" {:type :leaf, :by "root", :at 1530688640038, :text ":cdn-url", :id "Sy9d4xcMQ"}
-                       "j" {:type :leaf, :by "root", :at 1530688648495, :text "config/site", :id "HJFtEg9fm"}
+                       "D" {:type :leaf, :by "root", :at 1530688623527, :text "str", :id "ByPdVlqf7"}
+                       "L" {
+                        :type :expr, :by "root", :at 1530688637521, :id "SJUFEgqfm"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1530688640038, :text ":cdn-url", :id "Sy9d4xcMQ"}
+                         "j" {:type :leaf, :by "root", :at 1530688648495, :text "config/site", :id "HJFtEg9fm"}
+                        }
+                       }
+                       "T" {:type :leaf, :by "root", :at 1530688651873, :text "\"fontawesome/css/font-awesome.css", :id "ryliAGAtMQ"}
                       }
                      }
-                     "T" {:type :leaf, :by "root", :at 1530688651873, :text "\"fontawesome/css/font-awesome.css", :id "ryliAGAtMQ"}
                     }
                    }
                    "j" {

--- a/entry/main.css
+++ b/entry/main.css
@@ -31,10 +31,10 @@ body * {
 }
 
 .cell-container {
+  display: inline-flex;
   align-items: center;
   border: 1px solid rgb(250, 250, 250);
   color: rgb(179, 179, 179);
-  display: flex;
   flex-direction: column;
   font-size: 12px; height: 120px;
   justify-content: center;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "http-server": "^0.11.1",
-    "shadow-cljs": "^2.4.14"
+    "shadow-cljs": "^2.4.16"
   },
   "dependencies": {
     "copy-text-to-clipboard": "^1.0.4",

--- a/src/app/comp/container.cljs
+++ b/src/app/comp/container.cljs
@@ -73,13 +73,11 @@
     (comp-header (:content store))
     (list->
      {:style (merge
-              ui/row
               ui/flex
               {:flex-wrap :wrap,
                :padding "32px 16px 80px 16px",
-               :justify-content :center,
                :overflow :auto,
-               :align-items :flex-start})}
+               :text-align :center})}
      (->> icons-dict
           (filter (fn [[icon-name code]] (string/includes? code (or (:content store) ""))))
           (map (fn [[icon-name icon-code]] [icon-name (comp-icon icon-name icon-code)]))))

--- a/src/app/page.cljs
+++ b/src/app/page.cljs
@@ -33,7 +33,9 @@
      html-content
      (merge
       base-info
-      {:styles [(str (:cdn-url config/site) "fontawesome/css/font-awesome.css")
+      {:styles [(if local-bundle?
+                  "./fontawesome/css/font-awesome.css"
+                  (str (:cdn-url config/site) "fontawesome/css/font-awesome.css"))
                 (:release-ui config/site)],
        :scripts (map #(-> % :output-name prefix-cdn) assets),
        :ssr "respo-ssr",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1198,9 +1198,9 @@ shadow-cljs-jar@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.1.2.tgz#88664fae5957a7c21554e1a33476f1c475162c92"
 
-shadow-cljs@^2.4.14:
-  version "2.4.14"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.4.14.tgz#72d3b66efbb2d393d1083e694605ba222e401097"
+shadow-cljs@^2.4.16:
+  version "2.4.16"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.4.16.tgz#e017ac957eef9dc8dea333e0ed52a0d9d3287449"
   dependencies:
     babel-core "^6.26.0"
     babel-preset-env "^1.6.0"


### PR DESCRIPTION
Slightly changed layout http://repo.tiye.me/chenyong/fontawesome-finder/

In searching `ba`, with icons taking 2 or 3 lines, now icons are displayed on top, rather than in the middle.